### PR TITLE
Add Travis CI config & relax QuickCheck upper bound.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: c
+
+# explicitly request container-based infrastructure
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.1
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1],sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2],sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
+
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
+
+before_install:
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+

--- a/test-simple.cabal
+++ b/test-simple.cabal
@@ -19,7 +19,7 @@ Source-Repository head
 
 library 
   build-depends:  base < 5, mtl, template-haskell, state-plus >= 0.1.1 && < 0.2
-                    , QuickCheck >= 2.7.6 && < 2.8
+                    , QuickCheck >= 2.7.6 && < 2.9
   hs-source-dirs:   src
   ghc-options:      -Wall
   exposed-modules:  Test.Simple
@@ -27,7 +27,7 @@ library
 test-suite Main
   type:            exitcode-stdio-1.0
   build-depends:   base < 5, test-simple, process, executable-path, mtl
-                    , QuickCheck >= 2.7.6 && < 2.8
+                    , QuickCheck >= 2.7.6 && < 2.9
   ghc-options:     -Wall
   hs-source-dirs:  tests
   main-is:         Main.hs


### PR DESCRIPTION
Update QuickCheck upper bound for compatibility with Stackage LTS-4.2.  Added Travis CI config that tests GHC 7.8.4, 7.10.1, 7.10.2, 7.10.3, and 8.1 (head, at the time of this writing).

Travis results available [here](https://travis-ci.org/jship/test-simple).

Note that this makes progress on #1.  This package depends on state-plus, and that package's QuickCheck upper bound will need to be relaxed too.  I'll submit a PR for that project sent to you within a few minutes of this one.  Both of those packages will have to be updated on Hackage for Stackage compatibility.
